### PR TITLE
fix HAL_GPIO_TogglePin()

### DIFF
--- a/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_gpio.c
+++ b/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_gpio.c
@@ -441,14 +441,8 @@ void HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
   /* Check the parameters */
   assert_param(IS_GPIO_PIN(GPIO_Pin));
 
-  if ((GPIOx->ODR & GPIO_Pin) != 0X00u)
-  {
-    GPIOx->BSRR = (uint32_t)GPIO_Pin << GPIO_NUMBER;
-  }
-  else
-  {
-    GPIOx->BSRR = (uint32_t)GPIO_Pin;
-  }
+  GPIOx->BSRR = ((GPIOx->ODR & GPIO_Pin) << GPIO_NUMBER)
+                | ((GPIOx->ODR & GPIO_Pin) ^ GPIO_Pin);
 }
 
 /**


### PR DESCRIPTION
fix HAL_GPIO_TogglePin() to allow parameter of GPIO_Pin to be a combination of pins.

This fix will flip the pins given in GPIO_Pin and each individual
pin in GPIO_Pin doesn't has to be in a same state.

to verify the work, 
```
  HAL_GPIO_WritePin(GPIOC, LD3_Pin, GPIO_PIN_SET);
  HAL_GPIO_WritePin(GPIOC, LD4_Pin, GPIO_PIN_RESET);
  /* Infinite loop */
  for(;;)
  {
    osDelay(300);
    HAL_GPIO_TogglePin(GPIOC, LD4_Pin|LD3_Pin);
  }
```

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeF0/blob/master/CONTRIBUTING.md) file.
